### PR TITLE
fix: 🐞 clip backbone path correction to openai/clip-vit-base-patch32

### DIFF
--- a/configs/finetune_coco/yolo_world_l_dual_vlpan_2e-4_80e_8gpus_finetune_coco.py
+++ b/configs/finetune_coco/yolo_world_l_dual_vlpan_2e-4_80e_8gpus_finetune_coco.py
@@ -33,7 +33,7 @@ model = dict(
         image_model={{_base_.model.backbone}},
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=['all'])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               guide_channels=text_channels,

--- a/configs/finetune_coco/yolo_world_l_efficient_neck_2e-4_80e_8gpus_finetune_coco.py
+++ b/configs/finetune_coco/yolo_world_l_efficient_neck_2e-4_80e_8gpus_finetune_coco.py
@@ -30,7 +30,7 @@ model = dict(
         image_model={{_base_.model.backbone}},
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=['all'])),
     neck=dict(type='YOLOWorldPAFPN',
               guide_channels=text_channels,

--- a/configs/pretrain/yolo_world_x_dual_vlpan_l2norm_2e-3_100e_4x8gpus_obj365v1_goldg_train_lvis_minival.py
+++ b/configs/pretrain/yolo_world_x_dual_vlpan_l2norm_2e-3_100e_4x8gpus_obj365v1_goldg_train_lvis_minival.py
@@ -29,7 +29,7 @@ model = dict(
         image_model={{_base_.model.backbone}},
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=['all'])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               guide_channels=text_channels,

--- a/configs/segmentation/yolo_world_seg_l_dual_vlpan_2e-4_80e_8gpus_allmodules_finetune_lvis.py
+++ b/configs/segmentation/yolo_world_seg_l_dual_vlpan_2e-4_80e_8gpus_allmodules_finetune_lvis.py
@@ -38,7 +38,7 @@ model = dict(
         image_model={{_base_.model.backbone}},
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=[])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               guide_channels=text_channels,

--- a/configs/segmentation/yolo_world_seg_l_dual_vlpan_2e-4_80e_8gpus_seghead_finetune_lvis.py
+++ b/configs/segmentation/yolo_world_seg_l_dual_vlpan_2e-4_80e_8gpus_seghead_finetune_lvis.py
@@ -39,7 +39,7 @@ model = dict(
         frozen_stages=4,  # frozen the image backbone
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=['all'])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               freeze_all=True,

--- a/configs/segmentation/yolo_world_seg_m_dual_vlpan_2e-4_80e_8gpus_allmodules_finetune_lvis.py
+++ b/configs/segmentation/yolo_world_seg_m_dual_vlpan_2e-4_80e_8gpus_allmodules_finetune_lvis.py
@@ -38,7 +38,7 @@ model = dict(
         image_model={{_base_.model.backbone}},
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=[])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               guide_channels=text_channels,

--- a/configs/segmentation/yolo_world_seg_m_dual_vlpan_2e-4_80e_8gpus_seghead_finetune_lvis.py
+++ b/configs/segmentation/yolo_world_seg_m_dual_vlpan_2e-4_80e_8gpus_seghead_finetune_lvis.py
@@ -39,7 +39,7 @@ model = dict(
         frozen_stages=4,  # frozen the image backbone
         text_model=dict(
             type='HuggingCLIPLanguageBackbone',
-            model_name='pretrained_models/clip-vit-base-patch32-projection',
+            model_name='openai/clip-vit-base-patch32',
             frozen_modules=['all'])),
     neck=dict(type='YOLOWolrdDualPAFPN',
               freeze_all=True,


### PR DESCRIPTION
@wondervictor  I was testing Yolo-World-Seg and I notice that none of the segs parts wasn't working because of huggingface clip language backbone paths was not exist (If there is a other path I don't know please let me know) in order to use seg model I swap with openai path and I was able to segmentation 

Collab link : https://colab.research.google.com/drive/1zGWt29IpKBJaFHhtXP9-MSulLgVZzbOd?usp=sharing

Results are not what I expected so I am not sure what is wrong, If you have any idea please let me know too. 

PS : Collab results are looks like working because I manually edited the files 

