### PR TITLE
fix: should not call len func when custom_text default value is None

### DIFF
--- a/deploy/export_onnx.py
+++ b/deploy/export_onnx.py
@@ -105,7 +105,7 @@ def main():
             score_threshold=args.score_threshold)
         output_names = ['num_dets', 'boxes', 'scores', 'labels']
 
-    if len(args.custom_text) > 0:
+    if args.custom_text is not None and len(args.custom_text) > 0:
         with open(args.custom_text) as f:
             texts = json.load(f)
         texts = [x[0] for x in texts]


### PR DESCRIPTION
Found a small bug: when I run deploy/export_onnx.py without custom-text config,it will tell me:
```
if len(args.custom_text) > 0:
Type Error: object of type 'NoneType' has no len()
```