### PR TITLE
refactor the nms operation used in DeployModel to fix bug and support batch inference

### DIFF
--- a/deploy/easydeploy/nms/ort_nms.py
+++ b/deploy/easydeploy/nms/ort_nms.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 from torch import Tensor
+from torchvision.ops import batched_nms
 
 _XYWH2XYXY = torch.tensor([[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 0.0, 1.0],
                            [-0.5, 0.0, 0.5, 0.0], [0.0, -0.5, 0.0, 0.5]],
@@ -63,6 +64,40 @@ def select_nms_index(
     return num_dets, batched_dets, batched_scores, batched_labels
 
 
+def construct_indice(batch_idx, select_bbox_idxs, class_idxs, original_idxs):
+    num_bbox = len(select_bbox_idxs)
+    class_idxs = class_idxs[select_bbox_idxs]
+    indice = torch.zeros((num_bbox, 3), dtype=torch.int32).to(select_bbox_idxs.device)
+    # batch_idx
+    indice[:, 0] = batch_idx
+    # class_idxs
+    indice[:, 1] = class_idxs
+    # select_bbox_idxs
+    indice[:, 2] = original_idxs[select_bbox_idxs]
+    return indice
+
+
+def filter_max_boxes_per_class(
+    select_bbox_idxs, class_idxs, max_output_boxes_per_class
+):
+    class_counts = {}  #  used to track the count of each class
+
+    filtered_select_bbox_idxs = []
+    filtered_max_class_idxs = []
+
+    for bbox_idx, class_idx in zip(select_bbox_idxs, class_idxs):
+        class_count = class_counts.get(
+            class_idx.item(), 0
+        )  #  Get the count of the current class, or return 0 if it does not exist
+        if class_count < max_output_boxes_per_class:
+            filtered_select_bbox_idxs.append(bbox_idx)
+            filtered_max_class_idxs.append(class_idx)
+            class_counts[class_idx.item()] = class_count + 1
+    return torch.tensor(filtered_select_bbox_idxs), torch.tensor(
+        filtered_max_class_idxs
+    )
+
+
 class ONNXNMSop(torch.autograd.Function):
 
     @staticmethod
@@ -74,16 +109,63 @@ class ONNXNMSop(torch.autograd.Function):
         iou_threshold: Tensor = torch.tensor([0.5]),
         score_threshold: Tensor = torch.tensor([0.05])
     ) -> Tensor:
-        device = boxes.device
-        batch = scores.shape[0]
-        num_det = 20
-        batches = torch.randint(0, batch, (num_det, )).sort()[0].to(device)
-        idxs = torch.arange(100, 100 + num_det).to(device)
-        zeros = torch.zeros((num_det, ), dtype=torch.int64).to(device)
-        selected_indices = torch.cat([batches[None], zeros[None], idxs[None]],
-                                     0).T.contiguous()
-        selected_indices = selected_indices.to(torch.int64)
+        """
+        Non-Maximum Suppression (NMS) implementation.
 
+        Args:
+            boxes (Tensor): Bounding boxes of shape (batch_size, num_boxes, 4).
+            scores (Tensor): Confidence scores of shape (batch_size, num_classes, num_boxes).
+            max_output_boxes_per_class (Tensor): Maximum number of output boxes per class.
+            iou_threshold (Tensor): IoU threshold for NMS.
+            score_threshold (Tensor): Confidence score threshold.
+
+        Returns:
+            Tensor: Selected indices of shape (num_det, 3).first value is batch index, second value is class index, third value is box index
+        """
+        device = boxes.device
+        batch_size, num_classes, num_boxes = scores.shape
+        selected_indices = []
+        for batch_idx in range(batch_size):
+            boxes_per_image = boxes[batch_idx]
+            scores_per_image = scores[batch_idx]
+
+            # If no boxes in this image, continue to the next image
+            if boxes_per_image.numel() == 0:
+                continue
+
+            # for one box, only exist one class,so use torch.max to get the max score and class index
+            scores_per_image, class_idxs = torch.max(scores_per_image, dim=0)
+            # Apply score threshold before batched_nms bacause nms operation is time expensive
+            keep_idxs = scores_per_image > score_threshold
+            if not torch.any(keep_idxs):
+                # If no boxes left after applying score threshold, continue to the next image
+                continue
+
+            boxes_per_image = boxes_per_image[keep_idxs]
+            scores_per_image = scores_per_image[keep_idxs]
+            class_idxs = class_idxs[keep_idxs]
+
+            #  The purpose of original_idxs is we want to return the indexs to the original input data instead of the filtered.
+            original_idxs = torch.arange(num_boxes, device=device)[keep_idxs]
+            # reference: https://pytorch.org/vision/main/generated/torchvision.ops.batched_nms.html
+            select_bbox_idxs = batched_nms(
+                boxes_per_image, scores_per_image, class_idxs, iou_threshold
+            )
+            if (
+                select_bbox_idxs.shape[0] > max_output_boxes_per_class
+            ):  # If the boxes detected by all classes together are less than max_output_boxes_per_class, then there is no need to filter
+                select_bbox_idxs, _ = filter_max_boxes_per_class(
+                    select_bbox_idxs,
+                    class_idxs[select_bbox_idxs],
+                    max_output_boxes_per_class,
+                )
+            selected_indice = construct_indice(
+                batch_idx, select_bbox_idxs, class_idxs, original_idxs
+            )
+            selected_indices.append(selected_indice)
+        if len(selected_indices) == 0:
+            return torch.tensor([], device=device)
+        selected_indices = torch.cat(selected_indices, dim=0)
         return selected_indices
 
     @staticmethod

--- a/deploy/easydeploy/nms/ort_nms.py
+++ b/deploy/easydeploy/nms/ort_nms.py
@@ -104,8 +104,8 @@ def onnx_nms(
     box_coding: int = 0,
 ):
     max_output_boxes_per_class = torch.tensor([max_output_boxes_per_class])
-    iou_threshold = torch.tensor([iou_threshold])
-    score_threshold = torch.tensor([score_threshold])
+    iou_threshold = torch.tensor([iou_threshold]).to(boxes.device)
+    score_threshold = torch.tensor([score_threshold]).to(boxes.device)
 
     batch_size, _, _ = scores.shape
     if box_coding == 1:


### PR DESCRIPTION
[fix: sync device of the threshold to box](https://github.com/AILab-CVC/YOLO-World/pull/216/commits/139d50718fb56829ec225d760fd654cb82e724b1)
this commit sync the device to box to avoid the err with different device such as cpu and cuda.

[refactor select_nms_index to avoid meaningless zero memory usage](https://github.com/AILab-CVC/YOLO-World/pull/216/commits/5b4d701ff02eb90f32a594f6956d10ac7d545ebd)
This commit is because when I tried to use a multi-batch model to inference, I found the [select_nms_index func](https://github.com/AILab-CVC/YOLO-World/blob/cb6d2145a1b75a18da31a7117c21bf3aaadd44d6/deploy/easydeploy/nms/ort_nms.py#L10)(copy from mmyolo)'s process is strange. This function is currently used in onnx. when the batch-size of the exported onnx model is greater than 1 and it includes post-processing, there are the following problems (even if the exported model does not include post-processing, my first thought is to directly follow the original function to process the model output, which is more convenient and more accurate):

Suppose the batch size is 2, the first picture outputs 3 boxes, the second outputs 5 boxes, then it returns a box shape of [2,8,4] where for the first picture, the last 5 rows of data are all zeros, and for the second, the last three are all zeros. imagine if the batch size is 16, then there will be only 1 of the good data, and **the other 15 are all zeros, which is a big waste of memory (Also it didn't use keep_top_k param)**
an example:
```
batched_scores tensor([[0.9060, 0.8871, 0.8838, 0.8792, 0.8392, 0.8270, 0.7872, 0.5625, 0.5205,0.5076, 0.2859, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000],
        [0.9832, 0.8645, 0.8255, 0.7643, 0.5037, 0.0000, 0.0000, 0.0000, 0.0000,
         0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000]])
```

 So I rewrited this function.
First I'd like to return a List[tensor], the elements of the list can have different shapes, representing different pictures producing different numbers of bboxes. But this doesn't work for onnx, it splits the list into different outputs. It doesn't support this operation. In order to avoid too many output nodes, I directly stack the output of all the images together, according to the value of num_dets to take out the data corresponding to one image, the key code is:

```
    num_dets, batched_dets, batched_scores, batched_labels=outputs[0],outputs[1],outputs[2],outputs[3]
    cumulative_sum = torch.cumsum(num_dets, dim=0)
    cumulative_sum = torch.cat((torch.tensor([0]), cumulative_sum))
    start,end = cumulative_sum[batch_idx],cumulative_sum[batch_idx+1]
    bbox = batched_dets[start:end]
    scores = batched_scores[start:end]
```
So my impl's output shape is **a little different** from current:
**here is the current shape**,the output 0-3 correspond to num_dets, batched_dets, batched_scores, batched_labels:
<img src="https://github.com/AILab-CVC/YOLO-World/assets/63766429/b45e1157-ed59-492c-b4ff-bef4f29994a0" width="300px">
when the batch size is 2,the output shape just like (2,40,4) (if first image have 31 boxes and second image have 9 boxes,for (1,40,4),last 9 lines are zeros),Need to note that it add -1 at the end to identify the end, which is unnecessary as num_dets identifies the count of the boxes.
**here is my impl shape:**
<img src="https://github.com/AILab-CVC/YOLO-World/assets/63766429/be9e68d6-92a6-40f0-a2d3-c6abad15a2da" width="300px">
Just divide the data according to num_dets.can save many space in multi-batch condition.



[fix: wrong nms impl of onnx](https://github.com/AILab-CVC/YOLO-World/pull/216/commits/d457f21a04e1ea6f94dfa9aef279adbc7aff98a9)
this commit's reason is simple. The original ONNXNMSop's forward function **doesn't do the actual nms operation**, I'm guessing the reason is that this code was written to be used only when onnx.export, to do a fake forward, and when I tested it the exported model with post-processing, and the model call to ONNXNMSop.apply would actually call the symbolic function, so the result is correct. Without post-processing, that is, call it directly in python, the forward function is called, which doesn't actually do the nms operation, which leads to incorrectly drawn boxes. 

But, without post-processing is common because **post-processing is usually separate from model**, and for my case, if I use onnx to export the model with postprocess, the output shape is **dynamic(uncertain number of boxes)**, and if I want to change onnx to other model types, many model types(my case it is) don't support it well:reference:https://blog.csdn.net/qianqing13579/article/details/125660401)

**So what I done is I synchronized the forward function with symbolic func to allow us to use [the post-processing code](https://github.com/wufei-png/YOLO-World/blob/wf/test_refactor_nms/deploy/easydeploy/examples/postprocess.py) in the [DeployModel class](https://github.com/AILab-CVC/YOLO-World/blob/5ee2e01d52fd02aa75f731b145244ed204781d0f/deploy/easydeploy/model/model.py#L84) directly without having to write it again.**

**Finally, I test the related change code**, both in single batch and multi-batch, with and without post-processing, except the above output shape difference, it works good. But need to note that if batchsize > 2 and onnx model have post process, the ONNXNMSop.apply will actually call symbolic, it will not filter one box to only have one class, like this(same bbox have 2 class: dog and cat):
<img src="https://github.com/AILab-CVC/YOLO-World/assets/63766429/be306f37-4206-4d3b-8d6e-0e04056da2e9" width="500px">
**But my version do this filter to avoid this bug**, this need model no postprocess and call ONNXNMSop.forward to run my code. Certainly, we could deprecate this symbolic function and use my version of forward, but currently some of the functions in it such as torch.unique do not support onnx.But it's just a little and simple thing to replace it.

My added code is **formated by black** and I don't change the other code's format even if black change them.

**You can find the test code in my branch checkout from this pr branch**(add test code with post process with multi-batch support) and test it in this way:

```
git clone https://github.com/wufei-png/YOLO-World.git
git checkout wf/test_refactor_nms

test model without postprocess:

cd deploy
python export_onnx.py  --simplify  --batch-size 2 --model-only
cd easydeploy/examples
python batch_onnx_inference_without_postprocess.py

or test model with postprocess:

python export_onnx.py  --simplify  --batch-size 2 
cd easydeploy/examples
batch_onnx_inference_with_postprocess.py
```
The reason why I don't put the test code in this pr is because the code is not organised in a standardised way, e.g. missing code such as parser.add_argument,this is a small thing and not the main reason. It is  deploy/easydeploy/examples/main_onnxruntime.py does not support multi-batch, It's hard to make it compatible with this file, later you can see whether or how merge this multi-batch example into master comfortably.

I am willing to share **my batch lab result** for performance（big model is yolo-world-l,small is yolo-world-s）：
In 1060 6g pytorch:
![1060_fps](https://github.com/AILab-CVC/YOLO-World/assets/63766429/316fd657-7acf-4f94-af91-a9ec6f8639ad)
In 1060 6g onnx:
![1060_onnx_fps](https://github.com/AILab-CVC/YOLO-World/assets/63766429/fe13be8d-d05d-4b17-82f5-e5421611492d)
In HuaWei Ascend 310P:
![310p_fps_ano](https://github.com/AILab-CVC/YOLO-World/assets/63766429/ada4e01f-d8f3-413a-9ca5-8889a3b63a90)



