### PR TITLE
generate_image_prompts.py unnecessary txt embeddings

### DIFF
--- a/tools/generate_image_prompts.py
+++ b/tools/generate_image_prompts.py
@@ -26,16 +26,6 @@ if __name__ == "__main__":
     text_model = CLIPTextModelWithProjection.from_pretrained(args.model)
     processor = AutoProcessor.from_pretrained(args.model)
 
-    # padding prompts
-    device = 'cuda:0'
-    text_model.to(device)
-    texts = tokenizer(text=[' '], return_tensors='pt', padding=True)
-    texts = texts.to(device)
-    text_outputs = text_model(**texts)
-    txt_feats = text_outputs.text_embeds
-    txt_feats = txt_feats / txt_feats.norm(p=2, dim=-1, keepdim=True)
-    txt_feats = txt_feats.reshape(-1, txt_feats.shape[-1]).cpu().data.numpy()
-
     images = os.listdir(args.image_dir)
     category_embeds = []
 
@@ -54,6 +44,5 @@ if __name__ == "__main__":
 
     for image_ in tqdm.tqdm(images):
         _forward_vision_model(image_)
-    category_embeds.append(txt_feats)
     category_embeds = np.stack(category_embeds)
     np.save(osp.join(args.out_dir, args.out_file), category_embeds)


### PR DESCRIPTION

**Descriptilon:**

Deleted unnecessary ' ' (text) embeddings that cause a dimension error when stacked to image embeddings.

**Explanation**

The script to generate image embeddings was reclycled from the one used for text embeddings generation. 
This causes not only unnecessary text embeddings but a bug in which a dimension error show up. 

To be more specific, the line 37 that said: 
`txt_feats = txt_feats.reshape(-1, txt_feats.shape[-1]).cpu().data.numpy()`
Has the correct dimensions to be stored directly. However, after appending it to a list and np.stack it with the images embeddings (notice the [0] before converting it to numpy)
`img_feats = img_feats.reshape(-1, img_feats.shape[-1])[0].cpu().data.numpy()`
the dimensions of the np arrays to stack were not compatible. 

This can be solved in two ways. 

1. change the text embedding for
`txt_feats = txt_feats.reshape(-1, txt_feats.shape[-1]).cpu().data.numpy()` (notice the [0])
2. Directly avoiding the text embedding, as I suggest. 
