### PR TITLE
MaxSigmoidAttnBlock Enhancement

### DIFF
--- a/yolo_world/models/layers/yolo_bricks.py
+++ b/yolo_world/models/layers/yolo_bricks.py
@@ -39,7 +39,7 @@ class MaxSigmoidAttnBlock(BaseModule):
                 embed_channels % num_heads == 0), \
             'out_channels and embed_channels should be divisible by num_heads.'
         self.num_heads = num_heads
-        self.head_channels = out_channels // num_heads
+        self.head_channels = embed_channels // num_heads
         self.use_einsum = use_einsum
 
         self.embed_conv = ConvModule(


### PR DESCRIPTION
MaxSigmoidCSPLayerWithTwoConv is a nice module for fusing the image features and text features. But we found the param "embed_channels" only work when the embed_channels == out_channels*0.5, and there isn't any docs for this param's setting.

After deeply reading the code, we found an enhancement for "MaxSigmoidAttnBlock" module.

In "forward" function of "MaxSigmoidAttnBlock" module, the var "embed", which has the dims of "B, embed_channels, H, W" after "embed = self.embed_conv1(x)" called, is reshaped into "_, self.num_heads, self.head_channels, _, _". It means "embed_chanenls == self.num_heads * self.head_channels". 
And we found "self.head_channels = out_channels // num_heads" in "__init__". So "embed_channels" must be equal to "out_channels" in "MaxSigmoidAttnBlock".

In "MaxSigmoidCSPLayerWithTwoConv", the 'out_channels' of "MaxSigmoidAttnBlock" is set to be self.mid_channels which is equal to int(out_channels * expand_ratio) in Parent class "CSPLayerWithTwoConv"

Now, the chain is embed_channels(MaxSigmoidAttnBlock) = out_channels(MaxSigmoidAttnBlock) = self.mid_channels(MaxSigmoidCSPLayerWithTwoConv) = expand_ratio*out_channels(MaxSigmoidCSPLayerWithTwoConv)

The "expand_ratio" is set to be 0.5 defaultly. That is why we found "embed_channels != out_channels*0.5" doesn't work in MaxSigmoidCSPLayerWithTwoConv's param setting.

Actually, MaxSigmoidCSPLayerWithTwoConv only works when embed_channels = out_channels*expand_ratio.

For widely used in other models or applications, the param "embed_channels" in MaxSigmoidAttnBlock should be decoupled from the param of YOLOWorldDualPAFPN/YOLOWorldPAFPN.

From the upper analysis, "self.head_channels = embed_channels // num_heads" is more suitable for these module instead of "self.head_channels = out_channels // num_heads".