### PR TITLE
Fix ONNX demo postprocessing

### DIFF
--- a/deploy/onnx_demo.py
+++ b/deploy/onnx_demo.py
@@ -175,9 +175,9 @@ def inference_with_postprocessing(ort_session,
     bboxes = bboxes.cpu().numpy()
     labels = labels.cpu().numpy()
 
+    bboxes /= scale_factor
     bboxes -= np.array(
         [pad_param[1], pad_param[0], pad_param[1], pad_param[0]])
-    bboxes /= scale_factor
     bboxes[:, 0::2] = np.clip(bboxes[:, 0::2], 0, w)
     bboxes[:, 1::2] = np.clip(bboxes[:, 1::2], 0, h)
     bboxes = bboxes.round().astype('int')


### PR DESCRIPTION
Same fix as [here](https://github.com/AILab-CVC/YOLO-World/issues/466#issuecomment-2288000037) from @shiboyang

Tested with
```sh
python deploy/export_onnx.py \
  configs/pretrain/yolo_world_v2_l_vlpan_bn_2e-3_100e_4x8gpus_obj365v1_goldg_train_lvis_minival.py \
  demo/pretrained_weights/yolo_world_v2_l_obj365v1_goldg_pretrain-a82b1fe3.pth \
  --custom-text custom-text.json \
  --opset 12 --without-nms

python deploy/onnx_demo.py \
  work_dirs/yolo_world_v2_l_obj365v1_goldg_pretrain-a82b1fe3.onnx \
  <INPUT> custom-text.json \
  --onnx-nms
```