### PR TITLE
fix: ONNX export

### DIFF
--- a/yolo_world/models/detectors/yolo_world.py
+++ b/yolo_world/models/detectors/yolo_world.py
@@ -94,6 +94,7 @@ class YOLOWorldDetector(YOLODetector):
         if txt_feats is not None:
             # forward image only
             img_feats = self.backbone.forward_image(batch_inputs)
+            txt_masks = None
         else:
             img_feats, (txt_feats,
                         txt_masks) = self.backbone(batch_inputs, texts)


### PR DESCRIPTION
The `extract_feat` method in `YOLOWorldDetector` was missing initialization of txt_masks when using cached text features, causing ONNX export to fail with `UnboundLocalError`. This fix ensures `txt_masks` is properly initialized to `None` in all code paths.