### PR TITLE
Fix SyntaxError in YOLOWorldDetector.reparameterize

### DIFF
--- a/yolo_world/models/detectors/yolo_world.py
+++ b/yolo_world/models/detectors/yolo_world.py
@@ -58,7 +58,7 @@ class YOLOWorldDetector(YOLODetector):
     def reparameterize(self, texts: List[List[str]]) -> None:
         # encode text embeddings into the detector
         self.texts = texts
-        self.text_feats, None = self.backbone.forward_text(texts)
+        self.text_feats = self.backbone.forward_text(texts)
 
     def _forward(
             self,


### PR DESCRIPTION
## Summary

`yolo_world/models/detectors/yolo_world.py:61` contains a literal `SyntaxError`:

```python
self.text_feats, None = self.backbone.forward_text(texts)
```

`None` is a Python keyword and cannot appear on the left-hand side of an
assignment. Importing the package fails immediately with:

```
SyntaxError: cannot assign to None
```

Introduced in commit 1f12bca ("add mask"), 2025-02-27.

## Fix

Both `forward_text()` implementations in `yolo_world/models/backbones/mm_backbone.py`
return a single tensor, not a tuple:

- `PseudoLanguageBackbone.forward_text` at L172 returns `text_embeds`
- `MultiModalYOLOBackbone.forward_text` at L234 returns `txt_feats`

The other two call sites at L163 and L168 treat the return value as a
single value. The tuple-unpack here was spurious.

Fix by dropping the unpack:

```python
self.text_feats = self.backbone.forward_text(texts)
```

This is a one-line, one-file change.

## Test plan

- [x] `python -c "import yolo_world"` succeeds
- [x] `from yolo_world.models.detectors import YOLOWorldDetector` succeeds
- [x] `demo/image_demo.py` completes end-to-end with V2.1 L checkpoints (verified locally against both `l_stage1-7d280586.pth` at 640 resolution and `l_stage2-b3e3dc3f.pth` at 1280 resolution, since `image_demo.py` calls `model.reparameterize(texts)` at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)