### PR TITLE
Fix SyntaxError: cannot assign to None in yolo_world.py

### DIFF
--- a/yolo_world/models/detectors/yolo_world.py
+++ b/yolo_world/models/detectors/yolo_world.py
@@ -58,7 +58,7 @@ class YOLOWorldDetector(YOLODetector):
     def reparameterize(self, texts: List[List[str]]) -> None:
         # encode text embeddings into the detector
         self.texts = texts
-        self.text_feats, None = self.backbone.forward_text(texts)
+        self.text_feats, _ = self.backbone.forward_text(texts)
 
     def _forward(
             self,


### PR DESCRIPTION
### Description
This PR fixes a `SyntaxError` in `yolo_world/models/detectors/yolo_world.py` that occurs during model reparameterization. 

In Python, `None` is a keyword and cannot be used as an assignment target. The original code attempted to unpack the results of `self.backbone.forward_text(texts)` by assigning the second returned value to `None`, which immediately throws a `SyntaxError: cannot assign to None`.

### Changes Made
* Replaced `None` with `_` (underscore) on line 61. This correctly applies the standard Python convention for ignoring/discarding an unused return value during tuple unpacking, allowing the script to execute without crashing.